### PR TITLE
tests: (require 'pcache)

### DIFF
--- a/pcache-tests.el
+++ b/pcache-tests.el
@@ -26,6 +26,7 @@
 ;;; Code:
 
 (require 'ert)
+(require 'pcache)
 
 (defmacro pcache-with-repository (var arglist &rest body)
   (declare (indent 2) (debug t))


### PR DESCRIPTION
I bumped up against this when seeing if pcache could be build in [Homebrew](https://github.com/Homebrew/homebrew-emacs), where there's an ert helper method that needs this change to work; but it seems like a good idea in any case.
