### PR TITLE
Function hash-table-values is provided by subr-x

### DIFF
--- a/pcache.el
+++ b/pcache.el
@@ -56,6 +56,7 @@
 
 (require 'eieio)
 (require 'eieio-base)
+(require 'subr-x)
 
 (defvar pcache-directory
   (let ((dir (concat user-emacs-directory "var/pcache/")))


### PR DESCRIPTION
`pcache`'s constructor's call to `pcache-validate-repo` silently fails unless `subr-x` is `require`d.

This fixes https://github.com/rolandwalker/unicode-fonts/issues/21.