### PR TITLE
Rename deprecated `cl` package to `cl-lib`

### DIFF
--- a/pcache.el
+++ b/pcache.el
@@ -51,7 +51,7 @@
 
 ;;; Code:
 
-(require 'cl)
+(require 'cl-lib)
 (require 'eieio)
 (require 'eieio-base)
 


### PR DESCRIPTION
As of emacs 24.3 the cl package is deprecated. This shows a deprecation warning from emacs 27.1 and upwards.
New versions of emacs come with cl-lib which does not use cl internally and instead has backward-compatibility which internally uses cl-lib and just re-exports the same definitions under their old name.