### PR TITLE
remove directory creation from defvar form

### DIFF
--- a/pcache.el
+++ b/pcache.el
@@ -56,10 +56,7 @@
 (require 'eieio)
 (require 'eieio-base)
 
-(defvar pcache-directory
-  (let ((dir (concat user-emacs-directory "var/pcache/")))
-    (make-directory dir t)
-    dir))
+(defvar pcache-directory (concat user-emacs-directory "var/pcache/"))
 
 (defvar *pcache-repositories* (make-hash-table :test 'equal))
 


### PR DESCRIPTION
This fixes #6, by allowing pcache-directory to be set to a different location
without creating the default one.

This code was not needed anyway since make-instance creates the hierarchy as
needed.